### PR TITLE
Update test for WebAssembly.Exception.prototype.stack

### DIFF
--- a/custom-js.json
+++ b/custom-js.json
@@ -1125,7 +1125,9 @@
     },
     "WebAssembly.Exception.prototype.getArg": {},
     "WebAssembly.Exception.prototype.is": {},
-    "WebAssembly.Exception.prototype.stack": {},
+    "WebAssembly.Exception.prototype.stack": {
+      "ctor_args": "new WebAssembly.Tag({parameters:[]}),[], {traceStack:true}"
+    },
     "WebAssembly.Global": {
       "ctor_args": "{value:'i32'}"
     },


### PR DESCRIPTION
I believe this activates the `.stack` property.

Docs: https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Exception/stack