### PR TITLE
Added WebAssembly features

### DIFF
--- a/custom/wasm.json
+++ b/custom/wasm.json
@@ -1,0 +1,49 @@
+{
+  "features": {
+    "BigInt-to-i64-integration": {
+      "wfd-key": "bigInt"
+    },
+    "bulk-memory-operations": {
+      "wfd-key": "bulkMemory"
+    },
+    "extended-constant-expressions": {
+      "wfd-key": "extendedConst"
+    },
+    "multi-value": {
+      "wfd-key": "multiValue"
+    },
+    "mutable-globals": {
+      "wfd-key": "mutableGlobals"
+    },
+    "reference-types": {
+      "wfd-key": "referenceTypes"
+    },
+    "non-trapping-float-to-int-conversions": {
+      "wfd-key": "saturatedFloatToInt"
+    },
+    "sign-extension-operations": {
+      "wfd-key": "signExtensions"
+    },
+    "fixed-width-SIMD": {
+      "wfd-key": "simd"
+    },
+    "tail-calls": {
+      "wfd-key": "tailCall"
+    },
+    "exception-handling": {
+      "wfd-key": "exceptions"
+    },
+    "garbage-collection": {
+      "wfd-key": "gc"
+    },
+    "memory64": {
+      "wfd-key": "memory64"
+    },
+    "relaxed-SIMD": {
+      "wfd-key": "relaxedSimd"
+    },
+    "threads-and-atomics": {
+      "wfd-key": "threads"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "slugify": "1.6.6",
         "ua-parser-js": "1.0.35",
         "unique-string": "3.0.0",
+        "wasm-feature-detect": "^1.5.1",
         "winston": "3.9.0",
         "yargs": "17.7.2"
       },
@@ -12919,6 +12920,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.5.1.tgz",
+      "integrity": "sha512-GHr23qmuehNXHY4902/hJ6EV5sUANIJC3R/yMfQ7hWDg3nfhlcJfnIL96R2ohpIwa62araN6aN4bLzzzq5GXkg=="
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "slugify": "1.6.6",
     "ua-parser-js": "1.0.35",
     "unique-string": "3.0.0",
+    "wasm-feature-detect": "^1.5.1",
     "winston": "3.9.0",
     "yargs": "17.7.2"
   },

--- a/prepare-resources.ts
+++ b/prepare-resources.ts
@@ -18,6 +18,7 @@ const generatedDir = fileURLToPath(new URL('./generated', import.meta.url));
 
 const copyResources = async () => {
   const resources = [
+    ['wasm-feature-detect/dist/umd/index.js', 'resources/wasm-feature-detect'],
     ['json3/lib/json3.min.js', 'resources'],
     ['chai/chai.js', 'unittest'],
     ['mocha/mocha.css', 'unittest'],

--- a/prepare-resources.ts
+++ b/prepare-resources.ts
@@ -18,7 +18,6 @@ const generatedDir = fileURLToPath(new URL('./generated', import.meta.url));
 
 const copyResources = async () => {
   const resources = [
-    ['wasm-feature-detect/dist/umd/index.js', 'resources/wasm-feature-detect'],
     ['json3/lib/json3.min.js', 'resources'],
     ['chai/chai.js', 'unittest'],
     ['mocha/mocha.css', 'unittest'],
@@ -41,6 +40,11 @@ const copyResources = async () => {
     ['@mdi/font/fonts/materialdesignicons-webfont.woff2', 'fonts'],
     ['highlight.js/styles/stackoverflow-dark.css', 'resources/highlight.js'],
     ['highlight.js/styles/stackoverflow-light.css', 'resources/highlight.js'],
+    [
+      'wasm-feature-detect/dist/umd/index.js',
+      'resources',
+      'wasm-feature-detect.js',
+    ],
   ];
   for (const [srcInModules, destInGenerated, newFilename] of resources) {
     const src = fileURLToPath(

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -469,6 +469,9 @@
    * returns (TestResult): Whether the property is supported; if `value` is present,
    *   whether that value is supported with the property
    */
+  async function testWasmFeature(feature) {
+    return await wasmFeatureDetect[feature]();
+  }
   function testCSSProperty(name, value) {
     if (!value) {
       // Default to "inherit"
@@ -1581,6 +1584,7 @@
     testObjectName: testObjectName,
     testOptionParam: testOptionParam,
     testCSSProperty: testCSSProperty,
+    testWasmFeature: testWasmFeature,
     addInstance: addInstance,
     addTest: addTest,
     addCleanup: addCleanup,

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -8,7 +8,7 @@
 
 /* global console, document, window, location, navigator, XMLHttpRequest,
           self, Worker, Promise, setTimeout, clearTimeout, MessageChannel,
-          SharedWorker, hljs */
+          SharedWorker, hljs, wasmFeatureDetect */
 
 // This harness should work on as old browsers as possible and shouldn't depend
 // on any modern JavaScript features.

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -469,9 +469,6 @@
    * returns (TestResult): Whether the property is supported; if `value` is present,
    *   whether that value is supported with the property
    */
-  async function testWasmFeature(feature) {
-    return await wasmFeatureDetect[feature]();
-  }
   function testCSSProperty(name, value) {
     if (!value) {
       // Default to "inherit"
@@ -501,6 +498,17 @@
     }
 
     return { result: null, message: "Detection methods are not supported" };
+  }
+
+  /**
+   * Test a web assembly feature for support, using the `wasm-feature-detect` Node package
+   *
+   * feature (string): The web assembly feature name as defined in `wasm-feature-detect`
+   *
+   * returns (TestResult): Whether the web assembly feature is supported
+   */
+  function testWasmFeature(feature) {
+    return wasmFeatureDetect[feature]();
   }
 
   /**

--- a/test-builder/index.ts
+++ b/test-builder/index.ts
@@ -16,6 +16,7 @@ import customIDL from '../custom/idl/index.js';
 import {build as buildAPI} from './api.js';
 import {build as buildCSS} from './css.js';
 import {build as buildJS} from './javascript.js';
+import {build as buildWasm} from './webassembly.js';
 import {customTests} from './common.js';
 
 import type {IDLFiles} from '../types/types.js';
@@ -26,6 +27,9 @@ const customCSS = await fs.readJson(
 const customJS = await fs.readJson(
   new URL('../custom/js.json', import.meta.url),
 );
+const customWasm = await fs.readJson(
+  new URL('../custom/wasm.json', import.meta.url)
+);
 
 /* c8 ignore start */
 const build = async (customIDL: IDLFiles, customCSS) => {
@@ -35,11 +39,13 @@ const build = async (customIDL: IDLFiles, customCSS) => {
   const APITests = buildAPI(specIDLs, customIDL);
   const CSSTests = buildCSS(specCSS, customCSS);
   const JSTests = buildJS(customJS);
+  const WasmTests = buildWasm(customWasm);
   const tests = Object.assign(
     {__resources: customTests.__resources},
     APITests,
     CSSTests,
     JSTests,
+    WasmTests
   );
 
   await fs.writeJson(new URL('../tests.json', import.meta.url), tests);

--- a/test-builder/index.ts
+++ b/test-builder/index.ts
@@ -28,7 +28,7 @@ const customJS = await fs.readJson(
   new URL('../custom/js.json', import.meta.url),
 );
 const customWasm = await fs.readJson(
-  new URL('../custom/wasm.json', import.meta.url)
+  new URL('../custom/wasm.json', import.meta.url),
 );
 
 /* c8 ignore start */
@@ -45,7 +45,7 @@ const build = async (customIDL: IDLFiles, customCSS) => {
     APITests,
     CSSTests,
     JSTests,
-    WasmTests
+    WasmTests,
   );
 
   await fs.writeJson(new URL('../tests.json', import.meta.url), tests);

--- a/test-builder/webassembly.ts
+++ b/test-builder/webassembly.ts
@@ -17,9 +17,9 @@ const build = (customWasm) => {
     tests[path] = compileTest({
       raw: {
         // 'wfd-key' stands for 'wasm-feature-detect key'
-        code: `bcd.testWasmFeature('${details['wfd-key']}')`
+        code: `bcd.testWasmFeature('${details['wfd-key']}')`,
       },
-      exposure: ['Window']
+      exposure: ['WebAssembly'],
     });
   }
   return tests;

--- a/test-builder/webassembly.ts
+++ b/test-builder/webassembly.ts
@@ -1,0 +1,27 @@
+//
+// mdn-bcd-collector: test-builder/webassembly.ts
+// Functions directly related to building all of the WebAssembly tests
+//
+// © Gooborg Studios, Google LLC, Mozilla Corporation, Apple Inc
+// See the LICENSE file for copyright details
+//
+
+import {compileTest} from './common.js';
+
+const build = (customWasm) => {
+  const features = Object.entries(customWasm.features) as any[];
+
+  const tests = {};
+  for (const [feature, details] of features) {
+    const path = ['webassembly', 'features', feature].join('.');
+    tests[path] = compileTest({
+      raw: {
+        // 'wfd-key' stands for 'wasm-feature-detect key'
+        code: `bcd.testWasmFeature('${details['wfd-key']}')`
+      },
+      exposure: ['Window']
+    });
+  }
+  return tests;
+};
+export {build};

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -11,7 +11,12 @@ import type * as WebIDL2 from 'webidl2';
 
 export type InternalSupportStatement = SupportStatement | 'mirror';
 
-export type Exposure = 'Window' | 'Worker' | 'SharedWorker' | 'ServiceWorker';
+export type Exposure =
+  | 'Window'
+  | 'Worker'
+  | 'SharedWorker'
+  | 'ServiceWorker'
+  | 'WebAssembly';
 
 export type Resource =
   | {

--- a/views/tests.ejs
+++ b/views/tests.ejs
@@ -55,6 +55,7 @@ See the LICENSE file for copyright details
   }; %>
 </div>
 
+<script src="/resources/wasm-feature-detect/index.js"></script>
 <script src="/resources/harness.js"></script>
 
 <script>

--- a/views/tests.ejs
+++ b/views/tests.ejs
@@ -55,7 +55,6 @@ See the LICENSE file for copyright details
   }; %>
 </div>
 
-<script src="/resources/wasm-feature-detect/index.js"></script>
 <script src="/resources/harness.js"></script>
 
 <script>


### PR DESCRIPTION
Resolves mdn/browser-compat-data/issues/5796

Thanks @queengooborg for the new structure, it's a lot easier to make sense of the repo now.

**Basic structure:**
Added the `wasm-feature-detect` library, and `testWasmFeature` to the global `bcd` object. 
`testWasmFeature` just calls `wasm-feature-detect`.
All the tests are in `custom/wasm.json`, where they have a readable name as the key, and the `wasm-feature-detect` name as the `wfd-key` value.
